### PR TITLE
fix: clarify error message when reporting debugger missing

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ use std::time::{SystemTime, Duration};
 use std::sync::{Arc, Mutex};
 use std::ffi::OsString;
 use std::process::{Command, Stdio};
+use std::io;
 
 extern crate structopt;
 use structopt::StructOpt;
@@ -272,7 +273,20 @@ fn main() {
 
     trace!("synthesized debug command: {:?}", debug_cmd);
     
-    debug_cmd.status().expect("error running debug command");
+    match debug_cmd.status() {
+        Ok(_) => (),
+        Err(e) => {
+            match e.kind() {
+                io::ErrorKind::NotFound => {
+                    error!("debugger '{}' not found, ensure it is installed and available on PATH", debugger);
+                },
+                _ => {
+                    error!("{:?}", e);
+                    return;
+                }
+            }
+        }
+    }
 
     trace!("debug command done");
 }


### PR DESCRIPTION
When running cargo-debug with the default debugger (gdb) absent a panic will be generated:

```
❮ cargo debug build -- -- pubchem view data 13360
args: ["/Users/user/.cargo/bin/cargo-debug", "debug", "build", "--", "--", "pubchem", "view", "data", "13360"]
    Finished dev [unoptimized + debuginfo] target(s) in 0.12s
03:16:12 [INFO] selected binary: "/Users/user/personal/projects/histamix/target/debug/histamix"
thread 'main' panicked at src/main.rs:275:24:
error running debug command: Os { code: 2, kind: NotFound, message: "No such file or directory" }
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

The panic message doesn't clear indicate that it's the debugger binary that's absent.

This commit adds a bit more error handling to the debugger execution to indicate the cause of the error and suggest a remediation.